### PR TITLE
Fix buffer overflow bug and code cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ryu-js"
-version = "1.0.5" # don't forget to update html_root_url
+version = "0.1.0" # don't forget to update html_root_url
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "Apache-2.0 OR BSL-1.0"
-description = "Fast floating point to string conversion"
-repository = "https://github.com/dtolnay/ryu"
-documentation = "https://docs.rs/ryu"
+description = "Fast floating point to string conversion, ECMAScript compliant."
+repository = "https://github.com/boa-dev/ryu-js"
+documentation = "https://docs.rs/ryu-js"
 readme = "README.md"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Ryū
+# Ryū-js
 
-[<img alt="github" src="https://img.shields.io/badge/github-dtolnay/ryu-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/dtolnay/ryu)
-[<img alt="crates.io" src="https://img.shields.io/crates/v/ryu.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/ryu)
-[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-ryu-66c2a5?style=for-the-badge&labelColor=555555&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/ryu)
-[<img alt="build status" src="https://img.shields.io/github/workflow/status/dtolnay/ryu/CI/master?style=for-the-badge" height="20">](https://github.com/dtolnay/ryu/actions?query=branch%3Amaster)
+Ryū-js is a fork of the [ryu][ryu-crate] crate adjusted to comply to the ECMAScript [number-to-string][ntos] algorithm.
+This crate is used in the `Boa` crate for number to string conversions
+
+[ryu-crate]: https://crates.io/crates/ryu
+[ntos]: https://tc39.es/ecma262/#sec-numeric-types-number-tostring
 
 Pure Rust implementation of Ryū, an algorithm to quickly convert floating point
 numbers to decimal strings.
@@ -15,22 +16,19 @@ under the creative commons CC-BY-SA license.
 This Rust implementation is a line-by-line port of Ulf Adams' implementation in
 C, [https://github.com/ulfjack/ryu][upstream].
 
-*Requirements: this crate supports any compiler version back to rustc 1.31; it
-uses nothing from the Rust standard library so is usable from no_std crates.*
-
 [paper]: https://dl.acm.org/citation.cfm?id=3192369
 [upstream]: https://github.com/ulfjack/ryu/tree/1c413e127f8d02afd12eb6259bc80163722f1385
 
 ```toml
 [dependencies]
-ryu = "1.0"
+ryu-js = "1.0"
 ```
 
 ## Example
 
 ```rust
 fn main() {
-    let mut buffer = ryu::Buffer::new();
+    let mut buffer = ryu_js::Buffer::new();
     let printed = buffer.format(1.234);
     assert_eq!(printed, "1.234");
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,7 @@ macro_rules! benches {
             $(
                 #[bench]
                 fn $name(b: &mut Bencher) {
-                    let mut buf = ryu::Buffer::new();
+                    let mut buf = ryu_js::Buffer::new();
 
                     b.iter(move || {
                         let value = black_box($value);

--- a/examples/upstream_benchmark.rs
+++ b/examples/upstream_benchmark.rs
@@ -53,7 +53,7 @@ macro_rules! benchmark {
 
                 let t1 = std::time::SystemTime::now();
                 for _ in 0..ITERATIONS {
-                    throwaway += ryu::Buffer::new().format_finite(f).len();
+                    throwaway += ryu_js::Buffer::new().format_finite(f).len();
                 }
                 let duration = t1.elapsed().unwrap();
                 let nanos = duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64;

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1,20 +1,20 @@
 use crate::raw;
 #[cfg(maybe_uninit)]
 use core::mem::MaybeUninit;
-use core::{mem, slice, str};
+use core::{slice, str};
 #[cfg(feature = "no-panic")]
 use no_panic::no_panic;
 
-const NAN: &'static str = "NaN";
-const INFINITY: &'static str = "Infinity";
-const NEG_INFINITY: &'static str = "-Infinity";
+const NAN: &str = "NaN";
+const INFINITY: &str = "Infinity";
+const NEG_INFINITY: &str = "-Infinity";
 
 /// Safe API for formatting floating point numbers to text.
 ///
 /// ## Example
 ///
 /// ```
-/// let mut buffer = ryu::Buffer::new();
+/// let mut buffer = ryu_js::Buffer::new();
 /// let printed = buffer.format_finite(1.234);
 /// assert_eq!(printed, "1.234");
 /// ```
@@ -38,7 +38,7 @@ impl Buffer {
         #[cfg(not(maybe_uninit))]
         let bytes = unsafe { mem::uninitialized() };
 
-        Buffer { bytes: bytes }
+        Buffer { bytes }
     }
 
     /// Print a floating point number into this buffer and return a reference to
@@ -125,7 +125,7 @@ impl Sealed for f32 {
     #[inline]
     fn is_nonfinite(self) -> bool {
         const EXP_MASK: u32 = 0x7f800000;
-        let bits = unsafe { mem::transmute::<f32, u32>(self) };
+        let bits = self.to_bits();
         bits & EXP_MASK == EXP_MASK
     }
 
@@ -134,7 +134,7 @@ impl Sealed for f32 {
     fn format_nonfinite(self) -> &'static str {
         const MANTISSA_MASK: u32 = 0x007fffff;
         const SIGN_MASK: u32 = 0x80000000;
-        let bits = unsafe { mem::transmute::<f32, u32>(self) };
+        let bits = self.to_bits();
         if bits & MANTISSA_MASK != 0 {
             NAN
         } else if bits & SIGN_MASK != 0 {
@@ -154,7 +154,7 @@ impl Sealed for f64 {
     #[inline]
     fn is_nonfinite(self) -> bool {
         const EXP_MASK: u64 = 0x7ff0000000000000;
-        let bits = unsafe { mem::transmute::<f64, u64>(self) };
+        let bits = self.to_bits();
         bits & EXP_MASK == EXP_MASK
     }
 
@@ -163,7 +163,7 @@ impl Sealed for f64 {
     fn format_nonfinite(self) -> &'static str {
         const MANTISSA_MASK: u64 = 0x000fffffffffffff;
         const SIGN_MASK: u64 = 0x8000000000000000;
-        let bits = unsafe { mem::transmute::<f64, u64>(self) };
+        let bits = self.to_bits();
         if bits & MANTISSA_MASK != 0 {
             NAN
         } else if bits & SIGN_MASK != 0 {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -20,9 +20,9 @@ const NEG_INFINITY: &str = "-Infinity";
 /// ```
 pub struct Buffer {
     #[cfg(maybe_uninit)]
-    bytes: [MaybeUninit<u8>; 24],
+    bytes: [MaybeUninit<u8>; 25],
     #[cfg(not(maybe_uninit))]
-    bytes: [u8; 24],
+    bytes: [u8; 25],
 }
 
 impl Buffer {
@@ -34,7 +34,7 @@ impl Buffer {
         // assume_init is safe here, since this is an array of MaybeUninit, which does not need
         // to be initialized.
         #[cfg(maybe_uninit)]
-        let bytes = [MaybeUninit::<u8>::uninit(); 24];
+        let bytes = [MaybeUninit::<u8>::uninit(); 25];
         #[cfg(not(maybe_uninit))]
         let bytes = unsafe { mem::uninitialized() };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! ```
 //! fn main() {
-//!     let mut buffer = ryu::Buffer::new();
+//!     let mut buffer = ryu_js::Buffer::new();
 //!     let printed = buffer.format(1.234);
 //!     assert_eq!(printed, "1.234");
 //! }
@@ -89,7 +89,7 @@
 //! notation.
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/ryu/1.0.5")]
+#![doc(html_root_url = "https://docs.rs/ryu-js/0.1.0")]
 #![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -6,7 +6,7 @@ use self::mantissa::*;
 use crate::common;
 use crate::d2s::{self, *};
 use crate::f2s::*;
-use core::{mem, ptr};
+use core::ptr;
 #[cfg(feature = "no-panic")]
 use no_panic::no_panic;
 
@@ -41,7 +41,7 @@ use no_panic::no_panic;
 ///
 /// unsafe {
 ///     let mut buffer = [MaybeUninit::<u8>::uninit(); 24];
-///     let len = ryu::raw::format64(f, buffer.as_mut_ptr() as *mut u8);
+///     let len = ryu_js::raw::format64(f, buffer.as_mut_ptr() as *mut u8);
 ///     let slice = slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = str::from_utf8_unchecked(slice);
 ///     assert_eq!(print, "1.234");
@@ -50,7 +50,7 @@ use no_panic::no_panic;
 #[must_use]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
-    let bits = mem::transmute::<f64, u64>(f);
+    let bits = f.to_bits();
     let sign = ((bits >> (DOUBLE_MANTISSA_BITS + DOUBLE_EXPONENT_BITS)) & 1) != 0;
     let ieee_mantissa = bits & ((1u64 << DOUBLE_MANTISSA_BITS) - 1);
     let ieee_exponent =
@@ -146,7 +146,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 ///
 /// unsafe {
 ///     let mut buffer = [MaybeUninit::<u8>::uninit(); 16];
-///     let len = ryu::raw::format32(f, buffer.as_mut_ptr() as *mut u8);
+///     let len = ryu_js::raw::format32(f, buffer.as_mut_ptr() as *mut u8);
 ///     let slice = slice::from_raw_parts(buffer.as_ptr() as *const u8, len);
 ///     let print = str::from_utf8_unchecked(slice);
 ///     assert_eq!(print, "1.234");
@@ -155,7 +155,7 @@ pub unsafe fn format64(f: f64, result: *mut u8) -> usize {
 #[must_use]
 #[cfg_attr(feature = "no-panic", no_panic)]
 pub unsafe fn format32(f: f32, result: *mut u8) -> usize {
-    let bits = mem::transmute::<f32, u32>(f);
+    let bits = f.to_bits();
     let sign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;
     let ieee_mantissa = bits & ((1u32 << FLOAT_MANTISSA_BITS) - 1);
     let ieee_exponent =

--- a/src/s2d.rs
+++ b/src/s2d.rs
@@ -114,8 +114,7 @@ pub fn s2d(buffer: &[u8]) -> Result<f64, Error> {
     // whether the conversion was exact (trailing_zeros).
     let e2: i32;
     let m2: u64;
-    let mut trailing_zeros: bool;
-    if e10 >= 0 {
+    let mut trailing_zeros = if e10 >= 0 {
         // The length of m * 10^e in bits is:
         //   log2(m10 * 10^e10) = log2(m10) + e10 log2(10) = log2(m10) + e10 + e10 * log2(5)
         //
@@ -151,8 +150,7 @@ pub fn s2d(buffer: &[u8]) -> Result<f64, Error> {
         // requires that the largest power of 2 that divides m10 + e10 is
         // greater than e2. If e2 is less than e10, then the result must be
         // exact. Otherwise we use the existing multiple_of_power_of_2 function.
-        trailing_zeros =
-            e2 < e10 || e2 - e10 < 64 && multiple_of_power_of_2(m10, (e2 - e10) as u32);
+        e2 < e10 || e2 - e10 < 64 && multiple_of_power_of_2(m10, (e2 - e10) as u32)
     } else {
         e2 = floor_log2(m10)
             .wrapping_add(e10 as u32)
@@ -169,8 +167,9 @@ pub fn s2d(buffer: &[u8]) -> Result<f64, Error> {
             unsafe { d2s::DOUBLE_POW5_INV_SPLIT.get_unchecked(-e10 as usize) },
             j as u32,
         );
-        trailing_zeros = multiple_of_power_of_5(m10, -e10 as u32);
-    }
+
+        multiple_of_power_of_5(m10, -e10 as u32)
+    };
 
     // Compute the final IEEE exponent.
     let mut ieee_e2 = i32::max(0, e2 + DOUBLE_EXPONENT_BIAS as i32 + floor_log2(m2) as i32) as u32;

--- a/src/s2f.rs
+++ b/src/s2f.rs
@@ -114,8 +114,7 @@ pub fn s2f(buffer: &[u8]) -> Result<f32, Error> {
     // whether the conversion was exact (trailing_zeros).
     let e2: i32;
     let m2: u32;
-    let mut trailing_zeros: bool;
-    if e10 >= 0 {
+    let mut trailing_zeros = if e10 >= 0 {
         // The length of m * 10^e in bits is:
         //   log2(m10 * 10^e10) = log2(m10) + e10 log2(10) = log2(m10) + e10 + e10 * log2(5)
         //
@@ -146,8 +145,7 @@ pub fn s2f(buffer: &[u8]) -> Result<f32, Error> {
         // requires that the largest power of 2 that divides m10 + e10 is
         // greater than e2. If e2 is less than e10, then the result must be
         // exact. Otherwise we use the existing multiple_of_power_of_2 function.
-        trailing_zeros =
-            e2 < e10 || e2 - e10 < 32 && multiple_of_power_of_2_32(m10, (e2 - e10) as u32);
+        e2 < e10 || e2 - e10 < 32 && multiple_of_power_of_2_32(m10, (e2 - e10) as u32)
     } else {
         e2 = floor_log2(m10)
             .wrapping_add(e10 as u32)
@@ -159,8 +157,9 @@ pub fn s2f(buffer: &[u8]) -> Result<f32, Error> {
             .wrapping_sub(1)
             .wrapping_add(f2s::FLOAT_POW5_INV_BITCOUNT);
         m2 = mul_pow5_inv_div_pow2(m10, -e10 as u32, j);
-        trailing_zeros = multiple_of_power_of_5_32(m10, -e10 as u32);
-    }
+
+        multiple_of_power_of_5_32(m10, -e10 as u32)
+    };
 
     // Compute the final IEEE exponent.
     let mut ieee_e2 = i32::max(0, e2 + FLOAT_EXPONENT_BIAS as i32 + floor_log2(m2) as i32) as u32;

--- a/tests/common_test.rs
+++ b/tests/common_test.rs
@@ -66,18 +66,3 @@ fn test_log10_pow5() {
     assert_eq!(2, log10_pow5(4));
     assert_eq!(1831, log10_pow5(2620));
 }
-
-#[test]
-fn test_float_to_bits() {
-    assert_eq!(0, 0.0_f32.to_bits());
-    assert_eq!(0x40490fda, 3.1415926_f32.to_bits());
-}
-
-#[test]
-fn test_double_to_bits() {
-    assert_eq!(0, 0.0_f64.to_bits());
-    assert_eq!(
-        0x400921FB54442D18,
-        3.1415926535897932384626433_f64.to_bits(),
-    );
-}

--- a/tests/d2s_test.rs
+++ b/tests/d2s_test.rs
@@ -248,3 +248,12 @@ fn test_ecma262_compliance() {
     assert_eq!(pretty(-1111111111111111111111.0), "-1.1111111111111111e+21");
     assert_eq!(pretty(-0.000000123), "-1.23e-7");
 }
+
+#[test]
+fn max_size_double_to_string() {
+    // See: https://viewer.scuttlebot.io/%25LQo5KOMeR%2Baj%2BEj0JVg3qLRqr%2BwiKo74nS8Uz7o0LDM%3D.sha256
+    assert_eq!(
+        pretty(-0.0000015809161985788154),
+        "-0.0000015809161985788154"
+    );
+}

--- a/tests/d2s_test.rs
+++ b/tests/d2s_test.rs
@@ -18,15 +18,20 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
+#![allow(clippy::approx_constant)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::excessive_precision)]
+
 #[macro_use]
 mod macros;
 
 use std::f64;
 
 fn pretty(f: f64) -> String {
-    ryu::Buffer::new().format(f).to_owned()
+    ryu_js::Buffer::new().format(f).to_owned()
 }
 
+#[allow(clippy::int_plus_one)]
 fn ieee_parts_to_double(sign: bool, ieee_exponent: u32, ieee_mantissa: u64) -> f64 {
     assert!(ieee_exponent <= 2047);
     assert!(ieee_mantissa <= (1u64 << 53) - 1);
@@ -49,7 +54,7 @@ fn test_ryu() {
 #[test]
 fn test_random() {
     let n = if cfg!(miri) { 100 } else { 1000000 };
-    let mut buffer = ryu::Buffer::new();
+    let mut buffer = ryu_js::Buffer::new();
     for _ in 0..n {
         let f: f64 = rand::random();
         assert_eq!(f, buffer.format_finite(f).parse().unwrap());
@@ -62,7 +67,7 @@ fn test_non_finite() {
     for i in 0u64..1 << 23 {
         let f = f64::from_bits((((1 << 11) - 1) << 52) + (i << 29));
         assert!(!f.is_finite(), "f={}", f);
-        ryu::Buffer::new().format_finite(f);
+        ryu_js::Buffer::new().format_finite(f);
     }
 }
 

--- a/tests/f2s_test.rs
+++ b/tests/f2s_test.rs
@@ -18,13 +18,17 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
+#![allow(clippy::approx_constant)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::excessive_precision)]
+
 #[macro_use]
 mod macros;
 
 use std::f32;
 
 fn pretty(f: f32) -> String {
-    ryu::Buffer::new().format(f).to_owned()
+    ryu_js::Buffer::new().format(f).to_owned()
 }
 
 #[test]
@@ -44,7 +48,7 @@ fn test_ryu() {
 #[test]
 fn test_random() {
     let n = if cfg!(miri) { 100 } else { 1000000 };
-    let mut buffer = ryu::Buffer::new();
+    let mut buffer = ryu_js::Buffer::new();
     for _ in 0..n {
         let f: f32 = rand::random();
         assert_eq!(f, buffer.format_finite(f).parse().unwrap());
@@ -57,7 +61,7 @@ fn test_non_finite() {
     for i in 0u32..1 << 23 {
         let f = f32::from_bits((((1 << 8) - 1) << 23) + i);
         assert!(!f.is_finite(), "f={}", f);
-        ryu::Buffer::new().format_finite(f);
+        ryu_js::Buffer::new().format_finite(f);
     }
 }
 

--- a/tests/s2d_test.rs
+++ b/tests/s2d_test.rs
@@ -18,6 +18,7 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
+#![allow(clippy::float_cmp)]
 #![cfg(not(feature = "small"))]
 #![allow(dead_code)]
 
@@ -122,6 +123,7 @@ fn test_table_size_denormal() {
 }
 
 #[test]
+#[allow(clippy::excessive_precision)]
 fn test_issue157() {
     assert_eq!(
         1.2999999999999999E+154,

--- a/tests/s2f_test.rs
+++ b/tests/s2f_test.rs
@@ -19,6 +19,7 @@
 // KIND, either express or implied.
 
 #![allow(dead_code)]
+#![allow(clippy::float_cmp)]
 
 #[path = "../src/common.rs"]
 mod common;


### PR DESCRIPTION
This PR changes:
 - Fix buffer overflow with double to string greater than `24` (max is 25)
 - Some clippy error fixes
 - Rustfmt
 - Change readme and `Cargo.toml`